### PR TITLE
Make options TBB:malloc and TBB:proxy work for package consumers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from conans.errors import ConanInvalidConfiguration
 import os
 from conans import ConanFile, tools
 from conans.model.version import Version

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,6 @@ that have future-proof scalability"""
     options = {"shared": [True, False], "tbbmalloc": [True, False], "tbbproxy": [True, False]}
     default_options = {"shared": False, "tbbmalloc": False, "tbbproxy": False}
     _source_subfolder = "source_subfolder"
-    _targets = ["tbb"]
 
     def configure(self):
         if self.settings.os == "Macos" and \
@@ -62,17 +61,20 @@ that have future-proof scalability"""
         tools.replace_in_file(linux_include, "shell gcc", "shell $(CC)")
         tools.replace_in_file(linux_include, "= gcc", "= $(CC)")
 
+    def get_targets(self):
+        targets = ["tbb"]
+        if self.options.tbbmalloc:
+            targets.append("tbbmalloc")
+        if self.options.tbbproxy:
+            targets.append("tbbproxy")
+        return targets
+    
     def build(self):
         def add_flag(name, value):
             if name in os.environ:
                 os.environ[name] += ' ' + value
             else:
                 os.environ[name] = value
-
-        if self.options.tbbmalloc:
-            self._targets.append("tbbmalloc")
-        if self.options.tbbproxy:
-            self._targets.append("tbbproxy")
 
         extra = "" if self.settings.os == "Windows" or self.options.shared else "extra_inc=big_iron.inc"
         arch = "ia32" if self.settings.arch == "x86" else "intel64"
@@ -95,14 +97,15 @@ that have future-proof scalability"""
                 add_flag('CFLAGS', '-mrtm')
                 add_flag('CXXFLAGS', '-mrtm')
 
+            targets = self.get_targets()
             if self.is_msvc:
                 # intentionally not using vcvars for clang-cl yet
                 with tools.vcvars(self.settings):
-                    self.run("%s arch=%s %s %s" % (make, arch, extra, " ".join(self._targets)))
+                    self.run("%s arch=%s %s %s" % (make, arch, extra, " ".join(targets)))
             elif self.is_mingw:
-                self.run("%s arch=%s compiler=gcc %s %s" % (make, arch, extra, " ".join(self._targets)))
+                self.run("%s arch=%s compiler=gcc %s %s" % (make, arch, extra, " ".join(targets)))
             else:
-                self.run("%s arch=%s %s %s" % (make, arch, extra, " ".join(self._targets)))
+                self.run("%s arch=%s %s %s" % (make, arch, extra, " ".join(targets)))
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
@@ -133,6 +136,7 @@ that have future-proof scalability"""
     def package_info(self):
         suffix = "_debug" if self.settings.build_type == "Debug" else ""
         libs = {"tbb": "tbb", "tbbproxy": "tbbmalloc_proxy", "tbbmalloc": "tbbmalloc"}
-        self.cpp_info.libs = ["{}{}".format(libs[target], suffix) for target in self._targets]
+        targets = self.get_targets()
+        self.cpp_info.libs = ["{}{}".format(libs[target], suffix) for target in targets]
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")


### PR DESCRIPTION
Add appropriate libraries to cpp_info.libs when options tbbmalloc and tbbproxy are enabled.
